### PR TITLE
BUGFIX: make masonry recalculate layout after image's loaded

### DIFF
--- a/logic/viewmasonry.js
+++ b/logic/viewmasonry.js
@@ -35,10 +35,10 @@ function ViewMasonry()
       var imgLoad = imagesLoaded('.grid');
       function onAlways( instance ) {
         console.log('all images are loaded');
-        //this.msnry.layout();
+        this.msnry.layout();
         console.log(this.msnry);
       }
-      imgLoad.on( 'always', onAlways );
+      imgLoad.on( 'always', onAlways.bind(this) );
       // imgLoad.off( 'always', onAlways );
       imgLoad.on( 'progress', function(instance, image)
       {


### PR DESCRIPTION
`onAlways`'s scope was different from the outside, meaning when `this` get accessed in there, it isn't the same `this` that has `this.msnry`. Specifying the context (aka `this`) using `bind` fixes it.