### PR TITLE
css: get rid of link borders

### DIFF
--- a/asset/style.css
+++ b/asset/style.css
@@ -67,6 +67,11 @@ body {
   color: var(--color-itembg)
 }
 
+a:active, a:focus {
+  outline:0;
+  border: none;
+}
+
 /* LOADING */
 .loading-wave {
   display: inline-block;


### PR DESCRIPTION
the border appears when you click on any link, and it looks really out of place. this should get rid of it.