### PR TITLE
Fix bug with DONE : false filtering

### DIFF
--- a/logic/wrap.js
+++ b/logic/wrap.js
@@ -169,7 +169,7 @@ function Wrap()
               {
                 tempDatabase[keys[i]] = db[keys[i]];
               }
-              else if (value.DONE == false)
+              else if (value.DONE == 'false')
               {
                 tempDatabase[keys[i]] = db[keys[i]];
               }


### PR DESCRIPTION
Currently if the user filters by things that arent done, it would only show the entries that don't have a DONE flag, not those that has DONE : false. This is due to javascript not considering `'false' == false`