### PR TITLE
Removed duplicate entry in content settings

### DIFF
--- a/content/settings.js
+++ b/content/settings.js
@@ -13,7 +13,6 @@ const SETTINGS =
 	SHOWDATE: true,
 	SHOWAUTH: true,
 	SHOWTYPE: true,
-	SHOWDONE: true,
 	SHOWLINK: true,
 	SHOWLOWER: true,
 	SHOWTAGS: true,


### PR DESCRIPTION
`SHOWDONE: true,` is present twice in settings.js
